### PR TITLE
[ODOO1-54] - Auth api-key is added

### DIFF
--- a/addons/gradein/controllers/gradein_controller.py
+++ b/addons/gradein/controllers/gradein_controller.py
@@ -25,7 +25,7 @@ class GradeInController(http.Controller):
         )
         return data
 
-    @route("/gradein/questions/", type="http", auth="public", methods=["GET"])
+    @route("/gradein/questions/", type="http", auth="api_key", methods=["GET"])
     def get_gradein_questions(self):
 
         equipment_type_id = request.params.get("equipment_type_id")


### PR DESCRIPTION
Se agrega la autenticación por api.

Para poder probar este PR se deben seguir los siguientes pasos:

- Tener instalado el modulo Auth Api Key (https://github.com/franco-gareis/gradein_service/pull/39/)
- Crear una clave api para el usuario local (https://www.cybrosys.com/blog/generate-and-use-api-keys-odoo-14)
- Ingresar al menu Settings -> Technical -> Auth Api Key y guardar la key generada en el paso anterior seleccionando el usuario local.
- Agregar en el header de la solicitud la clave API-KEY con el valor de la key generada.

Se adjunta captura de ejemplo de postman

![Captura de pantalla de 2023-11-23 13-53-19](https://github.com/franco-gareis/gradein_service/assets/149095289/74b7c678-d4ab-478e-b323-119f96e187b0)
